### PR TITLE
fix(agno): Optional parameter annotation

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "superface"
-version = "0.1.1"
+version = "0.1.2"
 description = "Intelligent Tools for Agentic AI"
 authors = [{ name = "Superface Team", email = "hello@superface.ai" }]
 readme = "README.md"

--- a/python/src/superface/agno/superface.py
+++ b/python/src/superface/agno/superface.py
@@ -86,7 +86,7 @@ def json_schema_to_signature(schema: dict) -> t.List[Parameter]:
                 name=param_name,
                 kind=Parameter.POSITIONAL_OR_KEYWORD,
                 default=Parameter.empty if is_required else default_value,
-                annotation=annotation
+                annotation=annotation if is_required else t.Optional[annotation]
             )
 
             if is_required:


### PR DESCRIPTION
This PR fixes issue in Python SDK for Agno.

The optional parameters were annotated with their type and `None` default which breaks Agno's validation upon calling the tool function. They are now correctly annotated as optional type.