### PR TITLE
This PR fixes python tools schema generation

### DIFF
--- a/python/src/superface/agno/superface.py
+++ b/python/src/superface/agno/superface.py
@@ -66,6 +66,15 @@ class Superface:
         return self.client.is_tool_connected(user_id=user_id, tool_name=tool_name)
 
 def json_schema_to_signature(schema: dict) -> t.List[Parameter]:
+    type_mapping = {
+        'integer': int,
+        'number': float,
+        'string': str,
+        'boolean': bool,
+        'array': list,
+        'object': dict
+    }
+    
     required_parameters = []
     optional_parameters = []
 
@@ -76,20 +85,11 @@ def json_schema_to_signature(schema: dict) -> t.List[Parameter]:
         for param_name, param_schema in schema_properties.items():
             param_type = param_schema.get('type', 'any')
             
-            if param_type == 'integer':
-                annotation = int
-            elif param_type == 'number':
-                annotation = float
-            elif param_type == 'string':
-                annotation = str
-            elif param_type == 'boolean':
-                annotation = bool
-            elif param_type == 'array':
-                annotation = list
-            elif param_type == 'object':
-                annotation = dict
+            if isinstance(param_type, list):
+                mapped_types = [type_mapping.get(pt, t.Any) for pt in param_type if pt != "null"]
+                annotation = t.Union[tuple(mapped_types)] if mapped_types else t.Any
             else:
-                annotation = t.Any
+                annotation = type_mapping.get(param_type, t.Any)
             
             default_value = param_schema.get("default", None)
 
@@ -110,4 +110,3 @@ def json_schema_to_signature(schema: dict) -> t.List[Parameter]:
                 optional_parameters.append(param)
     
     return required_parameters + optional_parameters
-

--- a/python/src/superface/client/schema_transformer.py
+++ b/python/src/superface/client/schema_transformer.py
@@ -1,4 +1,4 @@
-from typing import Any, Type, Optional
+from typing import Any, Type, Optional, Union
 from pydantic import BaseModel, Field, create_model
 from enum import Enum
 
@@ -19,23 +19,28 @@ def json_schema_to_pydantic(schema: dict[str, Any]) -> Type[BaseModel]:
     for field_name, field_props in properties.items():
         json_type = field_props.get("type", "string")
         enum_values = field_props.get("enum")
-
+        
+        # Determine field type
         if enum_values:
-            enum_name = f"{field_name.capitalize()}Enum"
-            field_type = Enum(enum_name, {v: v for v in enum_values})
+            field_type = Enum(f"{field_name.capitalize()}Enum", {v: v for v in enum_values})
+        elif isinstance(json_type, list):
+            mapped_field_types = [type_mapping.get(t, Any) for t in json_type if t != "null"]
+            field_type = Union[tuple(mapped_field_types)] if mapped_field_types else Any
         else:
             field_type = type_mapping.get(json_type, Any)
 
-        default_value = field_props.get("default", ...)
-        nullable = field_props.get("nullable", False)
-        description = field_props.get("title", "")
-
+        # Handle nullable and optional fields
+        nullable = field_props.get("nullable", False) or (isinstance(json_type, list) and "null" in json_type)
         if nullable:
             field_type = Optional[field_type]
-
-        if field_name not in required_fields:
-            default_value = field_props.get("default", None)
-
-        model_fields[field_name] = (field_type, Field(default_value, description=description))
+        
+        # Set default value
+        default_value = field_props.get("default", None if field_name not in required_fields else ...)
+        
+        # Create field with metadata
+        model_fields[field_name] = (field_type, Field(
+            default_value, 
+            description=field_props.get("title", "")
+        ))
 
     return create_model(schema.get("title", "Schema"), **model_fields)


### PR DESCRIPTION
On server we didn't handle nullable values correctly. this was fixed in https://github.com/superfaceai/pod/pull/582.
Because we generate input schemas only on integration upload, the change on server didn't took any immediate effect.
But with newly uploaded integration, error start to appear, because python sdk didn't count with type being list of different types.