### PR TITLE
fix: enhance input schema handling and type mapping in Superface class

### DIFF
--- a/python/src/superface/agno/superface.py
+++ b/python/src/superface/agno/superface.py
@@ -1,5 +1,6 @@
 import json
 import typing as t
+from enum import Enum
 
 from agno.tools import Toolkit, Function
 
@@ -37,12 +38,26 @@ class Superface:
         tool_fn.__signature__ = Signature(tool_params)
         tool_fn.__annotations__ = annotations
 
+        print(f"superface_tool.input_schema_raw before: {superface_tool.input_schema_raw}")
+        # set type to all properties if not present
+        for prop, value in superface_tool.input_schema_raw['properties'].items():
+            print(f"prop: {prop}")
+            print(f"value: {value}")
+            if 'type' not in value:
+                value['type'] = 'string'
+
+        print(f"superface_tool.input_schema_raw after: {superface_tool.input_schema_raw}")
+
+        ggg = superface_tool.input_schema_raw
+        if 'type' not in ggg:
+            ggg['type'] = 'string'
+
         # ... however the full JSON schema and description that's used
         # in LLM is passed here.
         agno_tool = Function(
             name=superface_tool.name,
             description=superface_tool.description,
-            parameters=superface_tool.input_schema_raw,
+            parameters=ggg,
             entrypoint=tool_fn,
             sanitize_arguments=True,
         )
@@ -67,12 +82,12 @@ class Superface:
 
 def json_schema_to_signature(schema: dict) -> t.List[Parameter]:
     type_mapping = {
-        'integer': int,
-        'number': float,
-        'string': str,
-        'boolean': bool,
-        'array': list,
-        'object': dict
+        'integer': "integer",
+        'number': "number",
+        'string': "string",
+        'boolean': "boolean",
+        'array': "array",
+        'object': "object",
     }
     
     required_parameters = []
@@ -83,16 +98,22 @@ def json_schema_to_signature(schema: dict) -> t.List[Parameter]:
     
     if 'properties' in schema:
         for param_name, param_schema in schema_properties.items():
-            param_type = param_schema.get('type', 'any')
+            param_type = param_schema.get('type', "string")
+            print(f"param_name: {param_name}")
+            print(f"param_type: {param_type}")
+            print(f"param_schema: {param_schema}")
             
             if isinstance(param_type, list):
-                mapped_types = [type_mapping.get(pt, t.Any) for pt in param_type if pt != "null"]
-                annotation = t.Union[tuple(mapped_types)] if mapped_types else t.Any
+                mapped_types = [type_mapping.get(pt, "string") for pt in param_type if pt != "null"]
+                print(f"mapped_types: {mapped_types}")
+                annotation = t.Union[tuple(mapped_types)] if mapped_types else t.AnyStr
+                print(f"annotation: {annotation}")
             else:
-                annotation = type_mapping.get(param_type, t.Any)
-            
+                annotation = type_mapping.get(param_type, "string")
+                print(f"annotation: {annotation}")
+            # default_value = param_schema.get("default", "Celsius")
             default_value = param_schema.get("default", None)
-
+            print(f"default_value: {default_value}")
             is_required = param_name in required_params or param_schema.get(
                 "required", False
             )


### PR DESCRIPTION
- Added type assignment for properties in input schema if not present.
- Updated type mapping to use string literals instead of types for JSON schema conversion.
- Improved logging for better traceability of parameter types and default values.

@freaz, FYI, this debug version works for me like a charm for wttr in integration:

log:
```
param_name: city
param_type: string
param_schema: {'type': 'string', 'description': 'Name of the city including state and country, e.g.: "Prague, Czech Republic" or "New York City, NY, USA"', 'title': 'city'}
annotation: string
default_value: None
param_name: units
param_type: string
param_schema: {'enum': ['C', 'F', 'K'], 'description': 'Units used to represent temperature - Fahrenheit, Celsius, Kelvin\nCelsius by default', 'title': 'units'}
annotation: string
default_value: None
superface_tool.input_schema_raw before: {'type': 'object', 'required': ['city'], 'properties': {'city': {'type': 'string', 'description': 'Name of the city including state and country, e.g.: "Prague, Czech Republic" or "New York City, NY, USA"', 'title': 'city'}, 'units': {'enum': ['C', 'F', 'K'], 'description': 'Units used to represent temperature - Fahrenheit, Celsius, Kelvin\nCelsius by default', 'title': 'units'}}}
prop: city
value: {'type': 'string', 'description': 'Name of the city including state and country, e.g.: "Prague, Czech Republic" or "New York City, NY, USA"', 'title': 'city'}
prop: units
value: {'enum': ['C', 'F', 'K'], 'description': 'Units used to represent temperature - Fahrenheit, Celsius, Kelvin\nCelsius by default', 'title': 'units'}
superface_tool.input_schema_raw after: {'type': 'object', 'required': ['city'], 'properties': {'city': {'type': 'string', 'description': 'Name of the city including state and country, e.g.: "Prague, Czech Republic" or "New York City, NY, USA"', 'title': 'city'}, 'units': {'enum': ['C', 'F', 'K'], 'description': 'Units used to represent temperature - Fahrenheit, Celsius, Kelvin\nCelsius by default', 'title': 'units', 'type': 'string'}}}
```